### PR TITLE
Path updates, remove topic configs GET operation, update tests

### DIFF
--- a/src/main/java/com/github/eyefloaters/console/api/BrokersResource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/BrokersResource.java
@@ -15,11 +15,13 @@ import org.apache.kafka.clients.admin.Admin;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.github.eyefloaters.console.api.model.ConfigEntry;
 import com.github.eyefloaters.console.api.service.BrokerService;
 
-@Path("/api/clusters/{clusterId}/brokers")
+@Path("/api/kafkas/{clusterId}/nodes")
+@Tag(name = "Kafka Cluster Resources")
 public class BrokersResource {
 
     @Inject

--- a/src/main/java/com/github/eyefloaters/console/api/ClientFactory.java
+++ b/src/main/java/com/github/eyefloaters/console/api/ClientFactory.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
 
-import com.github.eyefloaters.console.api.service.ClusterService;
+import com.github.eyefloaters.console.api.service.KafkaClusterService;
 import com.github.eyefloaters.console.legacy.model.AdminServerException;
 import com.github.eyefloaters.console.legacy.model.ErrorType;
 
@@ -73,10 +73,10 @@ public class ClientFactory {
             return () -> null;
         }
 
-        Kafka cluster = ClusterService.findCluster(kafkaInformer, clusterId)
+        Kafka cluster = KafkaClusterService.findCluster(kafkaInformer, clusterId)
                 .orElseThrow(() -> new NotFoundException("Cluster not found for clusterId: " + clusterId));
 
-        Map<String, Object> config = ClusterService.externalListeners(cluster)
+        Map<String, Object> config = KafkaClusterService.externalListeners(cluster)
             .findFirst()
             .map(l -> buildConfiguration(cluster, l))
             .orElseThrow(() -> new NotFoundException("Cluster not found for clusterId: " + clusterId));
@@ -94,7 +94,7 @@ public class ClientFactory {
 
     Map<String, Object> buildConfiguration(Kafka cluster, ListenerStatus listenerStatus) {
         Map<String, Object> config = new HashMap<>();
-        String authType = ClusterService.getAuthType(cluster, listenerStatus).orElse("");
+        String authType = KafkaClusterService.getAuthType(cluster, listenerStatus).orElse("");
         boolean saslEnabled;
 
         switch (authType) {

--- a/src/main/java/com/github/eyefloaters/console/api/ClientFactory.java
+++ b/src/main/java/com/github/eyefloaters/console/api/ClientFactory.java
@@ -74,12 +74,12 @@ public class ClientFactory {
         }
 
         Kafka cluster = KafkaClusterService.findCluster(kafkaInformer, clusterId)
-                .orElseThrow(() -> new NotFoundException("Cluster not found for clusterId: " + clusterId));
+                .orElseThrow(() -> new NotFoundException("No such Kafka cluster: " + clusterId));
 
         Map<String, Object> config = KafkaClusterService.externalListeners(cluster)
             .findFirst()
             .map(l -> buildConfiguration(cluster, l))
-            .orElseThrow(() -> new NotFoundException("Cluster not found for clusterId: " + clusterId));
+            .orElseThrow(() -> new NotFoundException("No such Kafka cluster: " + clusterId));
 
         log.debug("AdminClient configuration:");
         config.entrySet().forEach(entry -> log.debugf("\t%s = %s", entry.getKey(), entry.getValue()));

--- a/src/main/java/com/github/eyefloaters/console/api/KafkaClustersResource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/KafkaClustersResource.java
@@ -13,30 +13,32 @@ import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-import com.github.eyefloaters.console.api.model.Cluster;
-import com.github.eyefloaters.console.api.service.ClusterService;
+import com.github.eyefloaters.console.api.model.KafkaCluster;
+import com.github.eyefloaters.console.api.service.KafkaClusterService;
 
-@Path("/api/clusters")
-public class ClustersResource {
+@Path("/api/kafkas")
+@Tag(name = "Kafka Cluster Resources")
+public class KafkaClustersResource {
 
     @Inject
-    ClusterService clusterService;
+    KafkaClusterService clusterService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @APIResponseSchema(Cluster.ListResponse.class)
+    @APIResponseSchema(KafkaCluster.ListResponse.class)
     @APIResponse(responseCode = "500", ref = "ServerError")
     @APIResponse(responseCode = "504", ref = "ServerTimeout")
     public Response listClusters() {
-        var responseEntity = new Cluster.ListResponse(clusterService.listClusters());
+        var responseEntity = new KafkaCluster.ListResponse(clusterService.listClusters());
         return Response.ok(responseEntity).build();
     }
 
     @GET
     @Path("{clusterId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @APIResponseSchema(Cluster.SingleResponse.class)
+    @APIResponseSchema(KafkaCluster.SingleResponse.class)
     @APIResponse(responseCode = "404", ref = "NotFound")
     @APIResponse(responseCode = "500", ref = "ServerError")
     @APIResponse(responseCode = "504", ref = "ServerTimeout")
@@ -46,7 +48,7 @@ public class ClustersResource {
             String clusterId) {
 
         return clusterService.describeCluster()
-            .thenApply(Cluster.SingleResponse::new)
+            .thenApply(KafkaCluster.SingleResponse::new)
             .thenApply(Response::ok)
             .thenApply(Response.ResponseBuilder::build);
     }

--- a/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
@@ -13,18 +13,18 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-import com.github.eyefloaters.console.api.model.ConfigEntry;
 import com.github.eyefloaters.console.api.model.Topic;
 import com.github.eyefloaters.console.api.service.TopicService;
 import com.github.eyefloaters.console.api.support.OffsetSpecValidator;
 
-@Path("/api/clusters/{clusterId}/topics")
+@Path("/api/kafkas/{clusterId}/topics")
+@Tag(name = "Kafka Cluster Resources")
 public class TopicsResource {
 
     @Inject
@@ -80,7 +80,7 @@ public class TopicsResource {
                 .thenApply(Response.ResponseBuilder::build);
     }
 
-    @Path("{topicName}")
+    @Path("{topicId}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @APIResponseSchema(Topic.SingleResponse.class)
@@ -88,9 +88,9 @@ public class TopicsResource {
     @APIResponse(responseCode = "500", ref = "ServerError")
     @APIResponse(responseCode = "504", ref = "ServerTimeout")
     public CompletionStage<Response> describeTopic(
-            @PathParam("topicName")
-            @Parameter(description = "Topic name")
-            String topicName,
+            @PathParam("topicId")
+            @Parameter(description = "Topic identifier")
+            String topicId,
 
             @QueryParam("include")
             List<String> includes,
@@ -106,26 +106,8 @@ public class TopicsResource {
             })
             String offsetSpec) {
 
-        return topicService.describeTopic(topicName, includes, offsetSpec)
+        return topicService.describeTopic(topicId, includes, offsetSpec)
                 .thenApply(Topic.SingleResponse::new)
-                .thenApply(Response::ok)
-                .thenApply(Response.ResponseBuilder::build);
-    }
-
-    @Path("{topicName}/configs")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @APIResponse(responseCode = "200", ref = "Configurations", content = @Content())
-    @APIResponse(responseCode = "404", ref = "NotFound")
-    @APIResponse(responseCode = "500", ref = "ServerError")
-    @APIResponse(responseCode = "504", ref = "ServerTimeout")
-    public CompletionStage<Response> describeTopicConfigs(
-            @PathParam("topicName")
-            @Parameter(description = "Topic name")
-            String topicName) {
-
-        return topicService.describeConfigs(topicName)
-                .thenApply(ConfigEntry.ConfigResponse::new)
                 .thenApply(Response::ok)
                 .thenApply(Response.ResponseBuilder::build);
     }

--- a/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
@@ -21,7 +21,9 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.github.eyefloaters.console.api.model.Topic;
 import com.github.eyefloaters.console.api.service.TopicService;
+import com.github.eyefloaters.console.api.support.ErrorCategory;
 import com.github.eyefloaters.console.api.support.OffsetSpecValidator;
+import com.github.eyefloaters.console.api.support.UuidValidator;
 
 @Path("/api/kafkas/{clusterId}/topics")
 @Tag(name = "Kafka Cluster Resources")
@@ -89,6 +91,7 @@ public class TopicsResource {
     @APIResponse(responseCode = "504", ref = "ServerTimeout")
     public CompletionStage<Response> describeTopic(
             @PathParam("topicId")
+            @UuidValidator.ValidUuid(category = ErrorCategory.RESOURCE_NOT_FOUND, message = "No such topic")
             @Parameter(description = "Topic identifier")
             String topicId,
 

--- a/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/TopicsResource.java
@@ -61,10 +61,6 @@ public class TopicsResource {
             @QueryParam("include")
             List<String> includes,
 
-            @QueryParam("listInternal")
-            @DefaultValue("false")
-            boolean listInternal,
-
             @QueryParam("offsetSpec")
             @DefaultValue("latest")
             @OffsetSpecValidator.ValidOffsetSpec
@@ -76,7 +72,7 @@ public class TopicsResource {
             })
             String offsetSpec) {
 
-        return topicService.listTopics(listInternal, includes, offsetSpec)
+        return topicService.listTopics(includes, offsetSpec)
                 .thenApply(Topic.ListResponse::new)
                 .thenApply(Response::ok)
                 .thenApply(Response.ResponseBuilder::build);

--- a/src/main/java/com/github/eyefloaters/console/api/model/ConfigEntry.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/ConfigEntry.java
@@ -9,18 +9,23 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@Schema(name = "ConfigAttributes")
 @JsonInclude(Include.NON_NULL)
 public class ConfigEntry {
 
-    public static class ConfigResponse extends DataResponse<Map<String, ConfigEntry>> {
+    public static class ConfigResponse extends DataResponse<ConfigResource> {
         public ConfigResponse(Map<String, ConfigEntry> data) {
-            super(data);
+            super(new ConfigResource(data));
         }
     }
 
-    public static class ConfigEntryMap extends java.util.HashMap<String, ConfigEntry> {
-        private static final long serialVersionUID = 1L;
-        private ConfigEntryMap() {
+    public interface ConfigEntryMap extends Map<String, ConfigEntry> {
+    }
+
+    @Schema(name = "Config")
+    public static final class ConfigResource extends Resource<Map<String, ConfigEntry>> {
+        public ConfigResource(Map<String, ConfigEntry> data) {
+            super(null, "configs", data);
         }
     }
 

--- a/src/main/java/com/github/eyefloaters/console/api/model/Error.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/Error.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonInclude(value = Include.NON_NULL)
 public class Error {
 
-    @Schema(enumeration = "Error", description = "Type of this object")
-    String kind = "Error";
+    @Schema(enumeration = "error", description = "Type of this object")
+    String type = "error";
 
     @Schema(description = "A unique identifier for this particular occurrence of the problem.")
     String id;
@@ -42,12 +42,8 @@ public class Error {
         this.cause = cause;
     }
 
-    public String getKind() {
-        return kind;
-    }
-
-    public void setKind(String kind) {
-        this.kind = kind;
+    public String getType() {
+        return type;
     }
 
     public String getId() {

--- a/src/main/java/com/github/eyefloaters/console/api/model/ErrorSource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/ErrorSource.java
@@ -7,50 +7,32 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @JsonInclude(value = Include.NON_NULL)
 @Schema(description = "An object containing references to the primary source of the error.")
-public class ErrorSource {
+public record ErrorSource(
+        /**
+         * A JSON Pointer [RFC6901] to the value in the request document that caused the
+         * error [e.g. "/data" for a primary data object, or "/data/attributes/title"
+         * for a specific attribute].
+         */
+        @Schema(description = """
+                A JSON Pointer [RFC6901] to the value in the request document that caused the
+                error [e.g. "/data" for a primary data object, or "/data/attributes/title"
+                for a specific attribute].
+                """)
+        String pointer,
 
-    /**
-     * A JSON Pointer [RFC6901] to the value in the request document that caused the
-     * error [e.g. "/data" for a primary data object, or "/data/attributes/title"
-     * for a specific attribute].
-     */
-    @Schema(description = """
-            A JSON Pointer [RFC6901] to the value in the request document that caused the
-            error [e.g. "/data" for a primary data object, or "/data/attributes/title"
-            for a specific attribute].
-            """)
-    final String pointer;
+        /**
+         * A string indicating which URI query parameter caused the error.
+         */
+        @Schema(description = "A string indicating which URI query parameter caused the error.")
+        String parameter,
 
-    /**
-     * A string indicating which URI query parameter caused the error.
-     */
-    @Schema(description = "A string indicating which URI query parameter caused the error.")
-    final String parameter;
-
-    /**
-     * A string indicating the name of a single request header which caused the
-     * error.
-     */
-    @Schema(description = "A string indicating the name of a single request header which caused the error.")
-    final String header;
-
-    public ErrorSource(String pointer, String parameter, String header) {
-        this.pointer = pointer;
-        this.parameter = parameter;
-        this.header = header;
-    }
-
-    public String getPointer() {
-        return pointer;
-    }
-
-    public String getParameter() {
-        return parameter;
-    }
-
-    public String getHeader() {
-        return header;
-    }
+        /**
+         * A string indicating the name of a single request header which caused the
+         * error.
+         */
+        @Schema(description = "A string indicating the name of a single request header which caused the error.")
+        String header
+) {
 
     @Override
     public String toString() {
@@ -63,6 +45,6 @@ public class ErrorSource {
         if (header != null) {
             return "header[" + header + ']';
         }
-        return super.toString();
+        return "empty";
     }
 }

--- a/src/main/java/com/github/eyefloaters/console/api/model/ErrorSource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/ErrorSource.java
@@ -19,43 +19,37 @@ public class ErrorSource {
             error [e.g. "/data" for a primary data object, or "/data/attributes/title"
             for a specific attribute].
             """)
-    String pointer;
+    final String pointer;
 
     /**
      * A string indicating which URI query parameter caused the error.
      */
     @Schema(description = "A string indicating which URI query parameter caused the error.")
-    String parameter;
+    final String parameter;
 
     /**
      * A string indicating the name of a single request header which caused the
      * error.
      */
     @Schema(description = "A string indicating the name of a single request header which caused the error.")
-    String header;
+    final String header;
+
+    public ErrorSource(String pointer, String parameter, String header) {
+        this.pointer = pointer;
+        this.parameter = parameter;
+        this.header = header;
+    }
 
     public String getPointer() {
         return pointer;
-    }
-
-    public void setPointer(String pointer) {
-        this.pointer = pointer;
     }
 
     public String getParameter() {
         return parameter;
     }
 
-    public void setParameter(String parameter) {
-        this.parameter = parameter;
-    }
-
     public String getHeader() {
         return header;
-    }
-
-    public void setHeader(String header) {
-        this.header = header;
     }
 
     @Override

--- a/src/main/java/com/github/eyefloaters/console/api/model/KafkaCluster.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/KafkaCluster.java
@@ -4,33 +4,43 @@ import java.util.List;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@Schema(name = "KafkaClusterAttributes")
+@JsonInclude(Include.NON_NULL)
 public class KafkaCluster {
 
     @Schema(name = "KafkaClusterListResponse")
-    public static final class ListResponse extends DataListResponse<KafkaCluster> {
+    public static final class ListResponse extends DataListResponse<KafkaClusterResource> {
         public ListResponse(List<KafkaCluster> data) {
-            super(data);
+            super(data.stream().map(KafkaClusterResource::new).toList());
         }
     }
 
     @Schema(name = "KafkaClusterResponse")
-    public static final class SingleResponse extends DataResponse<KafkaCluster> {
+    public static final class SingleResponse extends DataResponse<KafkaClusterResource> {
         public SingleResponse(KafkaCluster data) {
-            super(data);
+            super(new KafkaClusterResource(data));
         }
     }
 
-    String kind = "Cluster";
+    @Schema(name = "KafkaCluster")
+    public static final class KafkaClusterResource extends Resource<KafkaCluster> {
+        public KafkaClusterResource(KafkaCluster data) {
+            super(data.clusterId, "kafkas", data);
+        }
+    }
+
     String name; // Strimzi Kafka CR only
-    String clusterId;
-    List<Node> nodes;
-    Node controller;
-    List<String> authorizedOperations;
+    @JsonIgnore
+    final String clusterId;
+    final List<Node> nodes;
+    final Node controller;
+    final List<String> authorizedOperations;
     String bootstrapServers; // Strimzi Kafka CR only
     String authType; // Strimzi Kafka CR only
-
-    public KafkaCluster() {
-    }
 
     public KafkaCluster(String clusterId, List<Node> nodes, Node controller, List<String> authorizedOperations) {
         super();
@@ -38,10 +48,6 @@ public class KafkaCluster {
         this.nodes = nodes;
         this.controller = controller;
         this.authorizedOperations = authorizedOperations;
-    }
-
-    public String getKind() {
-        return kind;
     }
 
     public String getName() {
@@ -56,32 +62,16 @@ public class KafkaCluster {
         return clusterId;
     }
 
-    public void setClusterId(String clusterId) {
-        this.clusterId = clusterId;
-    }
-
     public List<Node> getNodes() {
         return nodes;
-    }
-
-    public void setNodes(List<Node> nodes) {
-        this.nodes = nodes;
     }
 
     public Node getController() {
         return controller;
     }
 
-    public void setController(Node controller) {
-        this.controller = controller;
-    }
-
     public List<String> getAuthorizedOperations() {
         return authorizedOperations;
-    }
-
-    public void setAuthorizedOperations(List<String> authorizedOperations) {
-        this.authorizedOperations = authorizedOperations;
     }
 
     public String getBootstrapServers() {

--- a/src/main/java/com/github/eyefloaters/console/api/model/KafkaCluster.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/KafkaCluster.java
@@ -4,18 +4,18 @@ import java.util.List;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-public class Cluster {
+public class KafkaCluster {
 
-    @Schema(name = "ClusterListResponse")
-    public static final class ListResponse extends DataListResponse<Cluster> {
-        public ListResponse(List<Cluster> data) {
+    @Schema(name = "KafkaClusterListResponse")
+    public static final class ListResponse extends DataListResponse<KafkaCluster> {
+        public ListResponse(List<KafkaCluster> data) {
             super(data);
         }
     }
 
-    @Schema(name = "ClusterResponse")
-    public static final class SingleResponse extends DataResponse<Cluster> {
-        public SingleResponse(Cluster data) {
+    @Schema(name = "KafkaClusterResponse")
+    public static final class SingleResponse extends DataResponse<KafkaCluster> {
+        public SingleResponse(KafkaCluster data) {
             super(data);
         }
     }
@@ -29,10 +29,10 @@ public class Cluster {
     String bootstrapServers; // Strimzi Kafka CR only
     String authType; // Strimzi Kafka CR only
 
-    public Cluster() {
+    public KafkaCluster() {
     }
 
-    public Cluster(String clusterId, List<Node> nodes, Node controller, List<String> authorizedOperations) {
+    public KafkaCluster(String clusterId, List<Node> nodes, Node controller, List<String> authorizedOperations) {
         super();
         this.clusterId = clusterId;
         this.nodes = nodes;

--- a/src/main/java/com/github/eyefloaters/console/api/model/Node.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/Node.java
@@ -1,57 +1,13 @@
 package com.github.eyefloaters.console.api.model;
 
-public class Node {
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
-    private int id;
-    private String host;
-    private int port;
-    private String rack;
-
-    public Node() {
-    }
-
-    public Node(int id, String host, int port, String rack) {
-        super();
-        this.id = id;
-        this.host = host;
-        this.port = port;
-        this.rack = rack;
-    }
+@JsonInclude(value = Include.NON_NULL)
+public record Node(int id, String host, int port, String rack) {
 
     public static Node fromKafkaModel(org.apache.kafka.common.Node node) {
         return new Node(node.id(), node.host(), node.port(), node.rack());
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getHost() {
-        return host;
-    }
-
-    public void setHost(String host) {
-        this.host = host;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-    public String getRack() {
-        return rack;
-    }
-
-    public void setRack(String rack) {
-        this.rack = rack;
     }
 
 }

--- a/src/main/java/com/github/eyefloaters/console/api/model/OffsetInfo.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/OffsetInfo.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonInclude(value = Include.NON_NULL)
 public class OffsetInfo {
 
-    String kind = "Offset";
     private long offset;
     private Instant timestamp;
     private Integer leaderEpoch;
@@ -21,10 +20,6 @@ public class OffsetInfo {
         this.offset = offset;
         this.timestamp = timestamp;
         this.leaderEpoch = leaderEpoch;
-    }
-
-    public String getKind() {
-        return kind;
     }
 
     public long getOffset() {

--- a/src/main/java/com/github/eyefloaters/console/api/model/OffsetInfo.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/OffsetInfo.java
@@ -6,44 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @JsonInclude(value = Include.NON_NULL)
-public class OffsetInfo {
-
-    private long offset;
-    private Instant timestamp;
-    private Integer leaderEpoch;
-
-    public OffsetInfo() {
-    }
-
-    public OffsetInfo(long offset, Instant timestamp, Integer leaderEpoch) {
-        super();
-        this.offset = offset;
-        this.timestamp = timestamp;
-        this.leaderEpoch = leaderEpoch;
-    }
-
-    public long getOffset() {
-        return offset;
-    }
-
-    public void setOffset(long offset) {
-        this.offset = offset;
-    }
-
-    public Instant getTimestamp() {
-        return timestamp;
-    }
-
-    public void setTimestamp(Instant timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public Integer getLeaderEpoch() {
-        return leaderEpoch;
-    }
-
-    public void setLeaderEpoch(Integer leaderEpoch) {
-        this.leaderEpoch = leaderEpoch;
-    }
+public record OffsetInfo(long offset, Instant timestamp, Integer leaderEpoch) {
 
 }

--- a/src/main/java/com/github/eyefloaters/console/api/model/PartitionInfo.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/PartitionInfo.java
@@ -4,21 +4,17 @@ import java.util.List;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-public class TopicPartitionInfo {
+public class PartitionInfo {
 
-    String kind = "Partition";
-    int partition;
-    Node leader;
-    List<Node> replicas;
-    List<Node> isr;
+    final int partition;
+    final Node leader;
+    final List<Node> replicas;
+    final List<Node> isr;
 
     @Schema(implementation = Object.class, oneOf = { OffsetInfo.class, Error.class })
     Either<OffsetInfo, Error> offset;
 
-    public TopicPartitionInfo() {
-    }
-
-    public TopicPartitionInfo(int partition, Node leader, List<Node> replicas, List<Node> isr) {
+    public PartitionInfo(int partition, Node leader, List<Node> replicas, List<Node> isr) {
         super();
         this.partition = partition;
         this.leader = leader;
@@ -26,11 +22,11 @@ public class TopicPartitionInfo {
         this.isr = isr;
     }
 
-    public static TopicPartitionInfo fromKafkaModel(org.apache.kafka.common.TopicPartitionInfo info) {
+    public static PartitionInfo fromKafkaModel(org.apache.kafka.common.TopicPartitionInfo info) {
         Node leader = Node.fromKafkaModel(info.leader());
         List<Node> replicas = info.replicas().stream().map(Node::fromKafkaModel).toList();
         List<Node> isr = info.isr().stream().map(Node::fromKafkaModel).toList();
-        return new TopicPartitionInfo(info.partition(), leader, replicas, isr);
+        return new PartitionInfo(info.partition(), leader, replicas, isr);
     }
 
     public void addOffset(Either<OffsetInfo, Throwable> offset) {
@@ -45,40 +41,20 @@ public class TopicPartitionInfo {
         }
     }
 
-    public String getKind() {
-        return kind;
-    }
-
     public int getPartition() {
         return partition;
-    }
-
-    public void setPartition(int partition) {
-        this.partition = partition;
     }
 
     public Node getLeader() {
         return leader;
     }
 
-    public void setLeader(Node leader) {
-        this.leader = leader;
-    }
-
     public List<Node> getReplicas() {
         return replicas;
     }
 
-    public void setReplicas(List<Node> replicas) {
-        this.replicas = replicas;
-    }
-
     public List<Node> getIsr() {
         return isr;
-    }
-
-    public void setIsr(List<Node> isr) {
-        this.isr = isr;
     }
 
     public Either<OffsetInfo, Error> getOffset() {

--- a/src/main/java/com/github/eyefloaters/console/api/model/Resource.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/Resource.java
@@ -1,0 +1,46 @@
+package com.github.eyefloaters.console.api.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public abstract class Resource<T> {
+
+    private final String id;
+    private final String type;
+    private final T attributes;
+    private Map<String, Object> meta;
+
+    protected Resource(String id, String type, T attributes) {
+        this.id = id;
+        this.type = type;
+        this.attributes = attributes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public T getAttributes() {
+        return attributes;
+    }
+
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
+    public Resource<T> addMeta(String key, Object value) {
+        if (meta == null) {
+            meta = new LinkedHashMap<>();
+        }
+        meta.put(key, value);
+        return this;
+    }
+}

--- a/src/main/java/com/github/eyefloaters/console/api/model/Topic.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/Topic.java
@@ -7,33 +7,42 @@ import java.util.Optional;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+@Schema(name = "TopicAttributes")
 @JsonInclude(value = Include.NON_NULL)
 public class Topic {
 
     @Schema(name = "TopicListResponse")
-    public static final class ListResponse extends DataListResponse<Topic> {
+    public static final class ListResponse extends DataListResponse<TopicResource> {
         public ListResponse(List<Topic> data) {
-            super(data);
+            super(data.stream().map(TopicResource::new).toList());
         }
     }
 
     @Schema(name = "TopicResponse")
-    public static final class SingleResponse extends DataResponse<Topic> {
+    public static final class SingleResponse extends DataResponse<TopicResource> {
         public SingleResponse(Topic data) {
-            super(data);
+            super(new TopicResource(data));
         }
     }
 
-    String kind = "Topic";
+    @Schema(name = "Topic")
+    public static final class TopicResource extends Resource<Topic> {
+        public TopicResource(Topic data) {
+            super(data.id, "topics", data);
+        }
+    }
+
     String name;
     boolean internal;
+    @JsonIgnore
     String id;
 
-    @Schema(implementation = Object.class, oneOf = { TopicPartitionInfo[].class, Error.class })
-    Either<List<TopicPartitionInfo>, Error> partitions;
+    @Schema(implementation = Object.class, oneOf = { PartitionInfo[].class, Error.class })
+    Either<List<PartitionInfo>, Error> partitions;
 
     @Schema(implementation = Object.class, oneOf = { String[].class, Error.class })
     Either<List<String>, Error> authorizedOperations;
@@ -60,7 +69,7 @@ public class Topic {
 
         topic.partitions = Either.of(description.partitions()
                 .stream()
-                .map(TopicPartitionInfo::fromKafkaModel)
+                .map(PartitionInfo::fromKafkaModel)
                 .toList());
 
         topic.authorizedOperations = Either.of(Optional.ofNullable(description.authorizedOperations())
@@ -106,10 +115,6 @@ public class Topic {
         }
     }
 
-    public String getKind() {
-        return kind;
-    }
-
     public String getName() {
         return name;
     }
@@ -118,7 +123,7 @@ public class Topic {
         return internal;
     }
 
-    public Either<List<TopicPartitionInfo>, Error> getPartitions() {
+    public Either<List<PartitionInfo>, Error> getPartitions() {
         return partitions;
     }
 

--- a/src/main/java/com/github/eyefloaters/console/api/model/Topic.java
+++ b/src/main/java/com/github/eyefloaters/console/api/model/Topic.java
@@ -30,7 +30,7 @@ public class Topic {
     String kind = "Topic";
     String name;
     boolean internal;
-    String topicId;
+    String id;
 
     @Schema(implementation = Object.class, oneOf = { TopicPartitionInfo[].class, Error.class })
     Either<List<TopicPartitionInfo>, Error> partitions;
@@ -44,11 +44,11 @@ public class Topic {
     public Topic() {
     }
 
-    public Topic(String name, boolean internal, String topicId) {
+    public Topic(String name, boolean internal, String id) {
         super();
         this.name = name;
         this.internal = internal;
-        this.topicId = topicId;
+        this.id = id;
     }
 
     public static Topic fromTopicListing(org.apache.kafka.clients.admin.TopicListing listing) {
@@ -126,8 +126,8 @@ public class Topic {
         return authorizedOperations;
     }
 
-    public String getTopicId() {
-        return topicId;
+    public String getId() {
+        return id;
     }
 
     public Either<Map<String, ConfigEntry>, Error> getConfigs() {

--- a/src/main/java/com/github/eyefloaters/console/api/package-info.java
+++ b/src/main/java/com/github/eyefloaters/console/api/package-info.java
@@ -1,5 +1,10 @@
 @OpenAPIDefinition(
         info = @Info(title = "", version = ""),
+        tags = {
+            @Tag(name = "Kafka Cluster Resources", description = """
+                    Operations related to Kafka clusters, configuration, and topics.
+                    """)
+        },
         components = @Components(
                 responses = {
                     @APIResponse(name = "Configurations",
@@ -132,6 +137,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import com.github.eyefloaters.console.api.model.ConfigEntry;
 import com.github.eyefloaters.console.api.model.ErrorResponse;

--- a/src/main/java/com/github/eyefloaters/console/api/service/BrokerService.java
+++ b/src/main/java/com/github/eyefloaters/console/api/service/BrokerService.java
@@ -28,7 +28,7 @@ public class BrokerService {
     public CompletionStage<Map<String, ConfigEntry>> describeConfigs(String nodeId) {
         return clusterService.describeCluster()
             .thenApply(cluster -> {
-                if (cluster.getNodes().stream().mapToInt(Node::getId).mapToObj(String::valueOf).noneMatch(nodeId::equals)) {
+                if (cluster.getNodes().stream().mapToInt(Node::id).mapToObj(String::valueOf).noneMatch(nodeId::equals)) {
                     throw new NotFoundException("No such broker: " + nodeId);
                 }
                 return cluster;

--- a/src/main/java/com/github/eyefloaters/console/api/service/BrokerService.java
+++ b/src/main/java/com/github/eyefloaters/console/api/service/BrokerService.java
@@ -17,7 +17,7 @@ import com.github.eyefloaters.console.api.model.Node;
 public class BrokerService {
 
     @Inject
-    ClusterService clusterService;
+    KafkaClusterService clusterService;
 
     @Inject
     ConfigService configService;

--- a/src/main/java/com/github/eyefloaters/console/api/service/KafkaClusterService.java
+++ b/src/main/java/com/github/eyefloaters/console/api/service/KafkaClusterService.java
@@ -43,9 +43,8 @@ public class KafkaClusterService {
                 .stream()
                 .flatMap(k -> externalListeners(k)
                         .map(l -> {
-                            KafkaCluster c = new KafkaCluster();
+                            KafkaCluster c = new KafkaCluster(k.getStatus().getClusterId(), null, null, null);
                             c.setName(k.getMetadata().getName());
-                            c.setClusterId(k.getStatus().getClusterId());
                             c.setBootstrapServers(l.getBootstrapServers());
                             c.setAuthType(getAuthType(k, l).orElse(null));
                             return c;

--- a/src/main/java/com/github/eyefloaters/console/api/service/KafkaClusterService.java
+++ b/src/main/java/com/github/eyefloaters/console/api/service/KafkaClusterService.java
@@ -16,7 +16,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.common.KafkaFuture;
 
-import com.github.eyefloaters.console.api.model.Cluster;
+import com.github.eyefloaters.console.api.model.KafkaCluster;
 import com.github.eyefloaters.console.api.model.Node;
 
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
@@ -29,7 +29,7 @@ import io.strimzi.api.kafka.model.status.ListenerStatus;
 import static com.github.eyefloaters.console.api.BlockingSupplier.get;
 
 @ApplicationScoped
-public class ClusterService {
+public class KafkaClusterService {
 
     @Inject
     SharedIndexInformer<Kafka> kafkaInformer;
@@ -37,13 +37,13 @@ public class ClusterService {
     @Inject
     Supplier<Admin> clientSupplier;
 
-    public List<Cluster> listClusters() {
+    public List<KafkaCluster> listClusters() {
         return kafkaInformer.getStore()
                 .list()
                 .stream()
                 .flatMap(k -> externalListeners(k)
                         .map(l -> {
-                            Cluster c = new Cluster();
+                            KafkaCluster c = new KafkaCluster();
                             c.setName(k.getMetadata().getName());
                             c.setClusterId(k.getStatus().getClusterId());
                             c.setBootstrapServers(l.getBootstrapServers());
@@ -53,7 +53,7 @@ public class ClusterService {
                 .toList();
     }
 
-    public CompletionStage<Cluster> describeCluster() {
+    public CompletionStage<KafkaCluster> describeCluster() {
         Admin adminClient = clientSupplier.get();
         DescribeClusterResult result = adminClient.describeCluster();
 
@@ -62,7 +62,7 @@ public class ClusterService {
                 result.clusterId(),
                 result.controller(),
                 result.nodes())
-            .thenApply(nothing -> new Cluster(
+            .thenApply(nothing -> new KafkaCluster(
                         get(result::clusterId),
                         get(result::nodes).stream().map(Node::fromKafkaModel).toList(),
                         Node.fromKafkaModel(get(result::controller)),
@@ -71,7 +71,7 @@ public class ClusterService {
             .toCompletionStage();
     }
 
-    Cluster addKafkaResourceData(Cluster cluster) {
+    KafkaCluster addKafkaResourceData(KafkaCluster cluster) {
         findCluster(kafkaInformer, cluster.getClusterId())
             .ifPresent(kafka -> externalListeners(kafka)
                     .forEach(l -> {

--- a/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
+++ b/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
@@ -19,7 +19,6 @@ import jakarta.inject.Inject;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
-import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicCollection;
@@ -66,10 +65,10 @@ public class TopicService {
 //                .toCompletionStage();
 //    }
 
-    public CompletionStage<List<Topic>> listTopics(boolean listInternal, List<String> includes, String offsetSpec) {
+    public CompletionStage<List<Topic>> listTopics(List<String> includes, String offsetSpec) {
         Admin adminClient = clientSupplier.get();
 
-        return adminClient.listTopics(new ListTopicsOptions().listInternal(listInternal))
+        return adminClient.listTopics()
                 .listings()
                 .thenApply(list -> list.stream().map(Topic::fromTopicListing).toList())
                 .toCompletionStage()

--- a/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
+++ b/src/main/java/com/github/eyefloaters/console/api/service/TopicService.java
@@ -3,6 +3,7 @@ package com.github.eyefloaters.console.api.service;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,9 +22,12 @@ import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicCollection;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
-import com.github.eyefloaters.console.api.model.ConfigEntry;
 import com.github.eyefloaters.console.api.model.Either;
 import com.github.eyefloaters.console.api.model.OffsetInfo;
 import com.github.eyefloaters.console.api.model.Topic;
@@ -73,11 +77,12 @@ public class TopicService {
                 .thenApply(list -> list.stream().sorted(Comparator.comparing(Topic::getName)).toList());
     }
 
-    public CompletionStage<Topic> describeTopic(String topicName, List<String> includes, String offsetSpec) {
+    public CompletionStage<Topic> describeTopic(String topicId, List<String> includes, String offsetSpec) {
         Admin adminClient = clientSupplier.get();
+        Uuid id = Uuid.fromString(topicId);
 
-        return describeTopics(adminClient, List.of(topicName), offsetSpec)
-            .thenApply(result -> result.get(topicName))
+        return describeTopics(adminClient, List.of(id), offsetSpec)
+            .thenApply(result -> result.get(id))
             .thenApply(result -> {
                 if (result.isPrimaryPresent()) {
                     return result.getPrimary();
@@ -88,7 +93,7 @@ public class TopicService {
                 CompletableFuture<Topic> promise = new CompletableFuture<>();
 
                 if (includes.contains("configs")) {
-                    List<ConfigResource> keys = List.of(new ConfigResource(ConfigResource.Type.TOPIC, topicName));
+                    List<ConfigResource> keys = List.of(new ConfigResource(ConfigResource.Type.TOPIC, topic.getName()));
                     configService.describeConfigs(adminClient, keys)
                         .thenApply(configs -> {
                             configs.forEach((name, either) -> topic.addConfigs(either));
@@ -102,10 +107,6 @@ public class TopicService {
 
                 return promise;
             });
-    }
-
-    public CompletionStage<Map<String, ConfigEntry>> describeConfigs(String topicName) {
-        return configService.describeConfigs(ConfigResource.Type.TOPIC, topicName);
     }
 
 //    public CompletionStage<Map<String, ConfigEntry>> alterConfigs(String topicName, Map<String, ConfigEntry> configs) {
@@ -152,22 +153,29 @@ public class TopicService {
 //    }
 
     CompletionStage<List<Topic>> augmentList(Admin adminClient, List<Topic> list, List<String> includes, String offsetSpec) {
-        Map<String, Topic> topics = list.stream().collect(Collectors.toMap(Topic::getName, Function.identity()));
+        Map<Uuid, Topic> topics = list.stream().collect(Collectors.toMap(t -> Uuid.fromString(t.getId()), Function.identity()));
         CompletableFuture<Void> configPromise = maybeDescribeConfigs(adminClient, topics, includes);
         CompletableFuture<Void> describePromise = maybeDescribeTopics(adminClient, topics, includes, offsetSpec);
 
         return CompletableFuture.allOf(configPromise, describePromise).thenApply(nothing -> list);
     }
 
-    CompletableFuture<Void> maybeDescribeConfigs(Admin adminClient, Map<String, Topic> topics, List<String> includes) {
+    CompletableFuture<Void> maybeDescribeConfigs(Admin adminClient, Map<Uuid, Topic> topics, List<String> includes) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
 
         if (includes.contains("configs")) {
-            List<ConfigResource> keys = topics.keySet().stream().map(name -> new ConfigResource(ConfigResource.Type.TOPIC, name)).toList();
+            Map<String, Uuid> topicIds = new HashMap<>();
+            List<ConfigResource> keys = topics.values().stream()
+                    .map(topic -> {
+                        topicIds.put(topic.getName(), Uuid.fromString(topic.getId()));
+                        return topic.getName();
+                    })
+                    .map(name -> new ConfigResource(ConfigResource.Type.TOPIC, name))
+                    .toList();
 
             configService.describeConfigs(adminClient, keys)
                 .thenApply(configs -> {
-                    configs.forEach((name, either) -> topics.get(name).addConfigs(either));
+                    configs.forEach((name, either) -> topics.get(topicIds.get(name)).addConfigs(either));
                     promise.complete(null);
                     return true; // Match `completeExceptionally`
                 })
@@ -179,7 +187,7 @@ public class TopicService {
         return promise;
     }
 
-    CompletableFuture<Void> maybeDescribeTopics(Admin adminClient, Map<String, Topic> topics, List<String> includes, String offsetSpec) {
+    CompletableFuture<Void> maybeDescribeTopics(Admin adminClient, Map<Uuid, Topic> topics, List<String> includes, String offsetSpec) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
 
         if (includes.contains("partitions") || includes.contains("authorizedOperations")) {
@@ -204,22 +212,29 @@ public class TopicService {
         return promise;
     }
 
-    CompletionStage<Map<String, Either<Topic, Throwable>>> describeTopics(Admin adminClient, Collection<String> topicNames, String offsetSpec) {
-        Map<String, Either<Topic, Throwable>> result = new LinkedHashMap<>(topicNames.size());
+    CompletionStage<Map<Uuid, Either<Topic, Throwable>>> describeTopics(Admin adminClient, Collection<Uuid> topicIds, String offsetSpec) {
+        Map<Uuid, Either<Topic, Throwable>> result = new LinkedHashMap<>(topicIds.size());
+        TopicCollection request = TopicCollection.ofTopicIds(topicIds);
 
-        var pendingDescribes = adminClient.describeTopics(topicNames)
-                .topicNameValues()
+        var pendingDescribes = adminClient.describeTopics(request)
+                .topicIdValues()
                 .entrySet()
                 .stream()
                 .map(entry ->
                     entry.getValue().toCompletionStage().<Void>handle((description, error) -> {
-                        result.put(entry.getKey(), Either.of(description, error, Topic::fromTopicDescription));
+                        if (error instanceof InvalidTopicException) {
+                            error = new UnknownTopicOrPartitionException(error);
+                        }
+
+                        result.put(
+                                entry.getKey(),
+                                Either.of(description, error, Topic::fromTopicDescription));
                         return null;
                     }))
                 .map(CompletionStage::toCompletableFuture)
                 .toArray(CompletableFuture[]::new);
 
-        var promise = new CompletableFuture<Map<String, Either<Topic, Throwable>>>();
+        var promise = new CompletableFuture<Map<Uuid, Either<Topic, Throwable>>>();
 
         CompletableFuture.allOf(pendingDescribes)
                 .thenCompose(nothing -> listOffsets(adminClient, result, offsetSpec))
@@ -229,7 +244,7 @@ public class TopicService {
         return promise;
     }
 
-    CompletionStage<Void> listOffsets(Admin adminClient, Map<String, Either<Topic, Throwable>> topics, String offsetSpec) {
+    CompletionStage<Void> listOffsets(Admin adminClient, Map<Uuid, Either<Topic, Throwable>> topics, String offsetSpec) {
         OffsetSpec reqOffsetSpec = switch (offsetSpec) {
             case "earliest"     -> OffsetSpec.earliest();
             case "latest"       -> OffsetSpec.latest();
@@ -237,9 +252,14 @@ public class TopicService {
             default             -> OffsetSpec.forTimestamp(Instant.parse(offsetSpec).toEpochMilli());
         };
 
+        Map<String, Uuid> topicIds = new HashMap<>();
         Map<org.apache.kafka.common.TopicPartition, OffsetSpec> request = topics.entrySet().stream()
                 .filter(entry -> entry.getValue().isPrimaryPresent())
-                .map(entry -> entry.getValue().getPrimary())
+                .map(entry -> {
+                    var topic = entry.getValue().getPrimary();
+                    topicIds.put(topic.getName(), entry.getKey());
+                    return topic;
+                })
                 .filter(topic -> topic.getPartitions().isPrimaryPresent())
                 .flatMap(topic -> topic.getPartitions().getPrimary()
                         .stream()
@@ -250,7 +270,7 @@ public class TopicService {
         var pendingOffsets = request.keySet().stream()
                 .map(topicPartition -> result.partitionResult(topicPartition)
                         .whenComplete((offsetResult, error) ->
-                        addOffset(topics.get(topicPartition.topic()).getPrimary(),
+                        addOffset(topics.get(topicIds.get(topicPartition.topic())).getPrimary(),
                                     topicPartition.partition(),
                                     offsetResult,
                                     error)))

--- a/src/main/java/com/github/eyefloaters/console/api/support/ConstraintViolationHandler.java
+++ b/src/main/java/com/github/eyefloaters/console/api/support/ConstraintViolationHandler.java
@@ -58,25 +58,6 @@ public class ConstraintViolationHandler implements ExceptionMapper<ConstraintVio
     }
 
     ErrorSource getSource(ErrorCategory category, String property) {
-        ErrorSource source = null;
-
-        switch (category.getSource()) {
-            case HEADER:
-                source = new ErrorSource();
-                source.setHeader(property);
-                break;
-            case PARAMETER:
-                source = new ErrorSource();
-                source.setParameter(property);
-                break;
-            case PAYLOAD:
-                source = new ErrorSource();
-                source.setPointer(property);
-                break;
-            default:
-                break;
-        }
-
-        return source;
+        return category.getSource().errorSource(property);
     }
 }

--- a/src/main/java/com/github/eyefloaters/console/api/support/ErrorCategory.java
+++ b/src/main/java/com/github/eyefloaters/console/api/support/ErrorCategory.java
@@ -3,6 +3,8 @@ package com.github.eyefloaters.console.api.support;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.Response.StatusType;
 
+import com.github.eyefloaters.console.api.model.ErrorSource;
+
 public enum ErrorCategory {
 
     INVALID_QUERY_PARAMETER("4001", "Invalid query parameter", Status.BAD_REQUEST, Source.PARAMETER),
@@ -15,7 +17,32 @@ public enum ErrorCategory {
 
 
     public enum Source {
-        PARAMETER, PAYLOAD, HEADER, NONE
+        PARAMETER {
+            @Override
+            public ErrorSource errorSource(String reference) {
+                return new ErrorSource(null, reference, null);
+            }
+        },
+        POINTER {
+            @Override
+            public ErrorSource errorSource(String reference) {
+                return new ErrorSource(reference, null, null);
+            }
+        },
+        HEADER {
+            @Override
+            public ErrorSource errorSource(String reference) {
+                return new ErrorSource(null, null, reference);
+            }
+        },
+        NONE {
+            @Override
+            public ErrorSource errorSource(String reference) {
+                return null;
+            }
+        };
+
+        public abstract ErrorSource errorSource(String reference);
     }
 
     private String title;

--- a/src/main/java/com/github/eyefloaters/console/api/support/UuidValidator.java
+++ b/src/main/java/com/github/eyefloaters/console/api/support/UuidValidator.java
@@ -1,0 +1,46 @@
+package com.github.eyefloaters.console.api.support;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+
+import org.apache.kafka.common.Uuid;
+
+public class UuidValidator implements ConstraintValidator<UuidValidator.ValidUuid, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        try {
+            Uuid.fromString(value);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Constraint(validatedBy = UuidValidator.class)
+    @Documented
+    public @interface ValidUuid {
+        String message();
+
+        Class<?>[] groups() default {};
+
+        Class<? extends Payload>[] payload() default {};
+
+        ErrorCategory category();
+
+    }
+}

--- a/src/test/java/com/github/eyefloaters/console/api/BrokersResourceIT.java
+++ b/src/test/java/com/github/eyefloaters/console/api/BrokersResourceIT.java
@@ -95,7 +95,7 @@ class BrokersResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data", not(anEmptyMap()))
-            .body("data.findAll { it }.collect { it.value }",
+            .body("data.attributes.findAll { it }.collect { it.value }",
                     everyItem(allOf(
                             hasKey("source"),
                             hasKey("sensitive"),

--- a/src/test/java/com/github/eyefloaters/console/api/KafkaClustersResourceIT.java
+++ b/src/test/java/com/github/eyefloaters/console/api/KafkaClustersResourceIT.java
@@ -145,12 +145,12 @@ class KafkaClustersResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", equalTo(2))
-            .body("data.name", containsInAnyOrder("test-kafka1", "test-kafka2"))
-            .body("data.clusterId", containsInAnyOrder(clusterId1, clusterId2))
-            .body("data.bootstrapServers", containsInAnyOrder(
+            .body("data.id", containsInAnyOrder(clusterId1, clusterId2))
+            .body("data.attributes.name", containsInAnyOrder("test-kafka1", "test-kafka2"))
+            .body("data.attributes.bootstrapServers", containsInAnyOrder(
                     bootstrapServers.getHost() + ":" + bootstrapServers.getPort(),
                     randomBootstrapServers.getHost() + ":" + randomBootstrapServers.getPort()))
-            .body("data.authType", containsInAnyOrder(equalTo("custom"), nullValue()));
+            .body("data.attributes.authType", containsInAnyOrder(equalTo("custom"), nullValue()));
     }
 
     @Test
@@ -196,10 +196,10 @@ class KafkaClustersResourceIT {
         whenRequesting(req -> req.get("{clusterId}", clusterId1))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
-            .body("data.name", equalTo("test-kafka1"))
-            .body("data.clusterId", equalTo(clusterId1))
-            .body("data.bootstrapServers", equalTo(bootstrapServers.getHost() + ":" + bootstrapServers.getPort()))
-            .body("data.authType", equalTo("custom"));
+            .body("data.id", equalTo(clusterId1))
+            .body("data.attributes.name", equalTo("test-kafka1"))
+            .body("data.attributes.bootstrapServers", equalTo(bootstrapServers.getHost() + ":" + bootstrapServers.getPort()))
+            .body("data.attributes.authType", equalTo("custom"));
     }
 
     @Test

--- a/src/test/java/com/github/eyefloaters/console/api/TopicsResourceIT.java
+++ b/src/test/java/com/github/eyefloaters/console/api/TopicsResourceIT.java
@@ -155,7 +155,7 @@ class TopicsResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(topicNames.size()))
-            .body("data.name", containsInAnyOrder(topicNames.toArray(String[]::new)));
+            .body("data.attributes.name", containsInAnyOrder(topicNames.toArray(String[]::new)));
     }
 
     @Test
@@ -179,9 +179,9 @@ class TopicsResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data.name", contains(topicName))
-            .body("data.configs[0]", not(anEmptyMap()))
-            .body("data.configs[0].findAll { it }.collect { it.value }",
+            .body("data.attributes.name", contains(topicName))
+            .body("data.attributes.configs[0]", not(anEmptyMap()))
+            .body("data.attributes.configs[0].findAll { it }.collect { it.value }",
                     everyItem(allOf(
                             hasKey("source"),
                             hasKey("sensitive"),
@@ -200,8 +200,8 @@ class TopicsResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data.name", contains(topicName))
-            .body("data.authorizedOperations", contains(nullValue()));
+            .body("data.attributes.name", contains(topicName))
+            .body("data.attributes.authorizedOperations", contains(nullValue()));
     }
 
     @Test
@@ -217,11 +217,11 @@ class TopicsResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data.name", contains(topicName))
-            .body("data.partitions[0]", hasSize(2))
-            .body("data.partitions[0][0].offset.kind", is("Offset"))
-            .body("data.partitions[0][0].offset.offset", is(2))
-            .body("data.partitions[0][0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.name", contains(topicName))
+            .body("data.attributes.partitions[0]", hasSize(2))
+            .body("data.attributes.partitions[0][0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0][0].offset.offset", is(2))
+            .body("data.attributes.partitions[0][0].offset.timestamp", is(nullValue()));
     }
 
     @Test
@@ -238,11 +238,11 @@ class TopicsResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data.name", contains(topicName))
-            .body("data.partitions[0]", hasSize(2))
-            .body("data.partitions[0][0].offset.kind", is("Offset"))
-            .body("data.partitions[0][0].offset.offset", is(0))
-            .body("data.partitions[0][0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.name", contains(topicName))
+            .body("data.attributes.partitions[0]", hasSize(2))
+            .body("data.attributes.partitions[0][0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0][0].offset.offset", is(0))
+            .body("data.attributes.partitions[0][0].offset.timestamp", is(nullValue()));
     }
 
     @Test
@@ -262,11 +262,11 @@ class TopicsResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data.name", contains(topicName))
-            .body("data.partitions[0]", hasSize(2))
-            .body("data.partitions[0][0].offset.kind", is("Offset"))
-            .body("data.partitions[0][0].offset.offset", is(0))
-            .body("data.partitions[0][0].offset.timestamp", is(first.toString()));
+            .body("data.attributes.name", contains(topicName))
+            .body("data.attributes.partitions[0]", hasSize(2))
+            .body("data.attributes.partitions[0][0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0][0].offset.offset", is(0))
+            .body("data.attributes.partitions[0][0].offset.timestamp", is(first.toString()));
     }
 
     @Test
@@ -286,11 +286,11 @@ class TopicsResourceIT {
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
             .body("data.size()", is(1))
-            .body("data.name", contains(topicName))
-            .body("data.partitions[0]", hasSize(2))
-            .body("data.partitions[0][0].offset.kind", is("Offset"))
-            .body("data.partitions[0][0].offset.offset", is(1))
-            .body("data.partitions[0][0].offset.timestamp", is(second.toString()));
+            .body("data.attributes.name", contains(topicName))
+            .body("data.attributes.partitions[0]", hasSize(2))
+            .body("data.attributes.partitions[0][0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0][0].offset.offset", is(1))
+            .body("data.attributes.partitions[0][0].offset.timestamp", is(second.toString()));
     }
 
 
@@ -304,9 +304,9 @@ class TopicsResourceIT {
                 .get("{topicName}", clusterId1, topicIds.get(topicName)))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
-            .body("data.name", is(topicName))
-            .body("data.configs", not(anEmptyMap()))
-            .body("data.configs.findAll { it }.collect { it.value }",
+            .body("data.attributes.name", is(topicName))
+            .body("data.attributes.configs", not(anEmptyMap()))
+            .body("data.attributes.configs.findAll { it }.collect { it.value }",
                     everyItem(allOf(
                             hasKey("source"),
                             hasKey("sensitive"),
@@ -322,10 +322,10 @@ class TopicsResourceIT {
         whenRequesting(req -> req.get("{topicName}", clusterId1, topicIds.get(topicName)))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
-            .body("data.name", is(topicName))
-            .body("data", not(hasKey("configs")))
-            .body("data", hasKey("authorizedOperations"))
-            .body("data.authorizedOperations", is(nullValue()));
+            .body("data.attributes.name", is(topicName))
+            .body("data.attributes", not(hasKey("configs")))
+            .body("data.attributes", hasKey("authorizedOperations"))
+            .body("data.attributes.authorizedOperations", is(nullValue()));
     }
 
     @Test
@@ -338,12 +338,12 @@ class TopicsResourceIT {
         whenRequesting(req -> req.get("{topicName}", clusterId1, topicIds.get(topicName)))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
-            .body("data.name", is(topicName))
-            .body("data", not(hasKey("configs")))
-            .body("data.partitions", hasSize(2))
-            .body("data.partitions[0].offset.kind", is("Offset"))
-            .body("data.partitions[0].offset.offset", is(2))
-            .body("data.partitions[0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.name", is(topicName))
+            .body("data.attributes", not(hasKey("configs")))
+            .body("data.attributes.partitions", hasSize(2))
+            .body("data.attributes.partitions[0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0].offset.offset", is(2))
+            .body("data.attributes.partitions[0].offset.timestamp", is(nullValue()));
     }
 
     @Test
@@ -358,12 +358,12 @@ class TopicsResourceIT {
                 .get("{topicName}", clusterId1, topicIds.get(topicName)))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
-            .body("data.name", is(topicName))
-            .body("data", not(hasKey("configs")))
-            .body("data.partitions", hasSize(2))
-            .body("data.partitions[0].offset.kind", is("Offset"))
-            .body("data.partitions[0].offset.offset", is(0))
-            .body("data.partitions[0].offset.timestamp", is(nullValue()));
+            .body("data.attributes.name", is(topicName))
+            .body("data.attributes", not(hasKey("configs")))
+            .body("data.attributes.partitions", hasSize(2))
+            .body("data.attributes.partitions[0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0].offset.offset", is(0))
+            .body("data.attributes.partitions[0].offset.timestamp", is(nullValue()));
     }
 
     @Test
@@ -381,12 +381,12 @@ class TopicsResourceIT {
                 .get("{topicName}", clusterId1, topicIds.get(topicName)))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
-            .body("data.name", is(topicName))
-            .body("data", not(hasKey("configs")))
-            .body("data.partitions", hasSize(2))
-            .body("data.partitions[0].offset.kind", is("Offset"))
-            .body("data.partitions[0].offset.offset", is(0))
-            .body("data.partitions[0].offset.timestamp", is(first.toString()));
+            .body("data.attributes.name", is(topicName))
+            .body("data.attributes", not(hasKey("configs")))
+            .body("data.attributes.partitions", hasSize(2))
+            .body("data.attributes.partitions[0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0].offset.offset", is(0))
+            .body("data.attributes.partitions[0].offset.timestamp", is(first.toString()));
     }
 
     @Test
@@ -404,12 +404,12 @@ class TopicsResourceIT {
                 .get("{topicName}", clusterId1, topicIds.get(topicName)))
             .assertThat()
             .statusCode(is(Status.OK.getStatusCode()))
-            .body("data.name", is(topicName))
-            .body("data", not(hasKey("configs")))
-            .body("data.partitions", hasSize(2))
-            .body("data.partitions[0].offset.kind", is("Offset"))
-            .body("data.partitions[0].offset.offset", is(1))
-            .body("data.partitions[0].offset.timestamp", is(second.toString()));
+            .body("data.attributes.name", is(topicName))
+            .body("data.attributes", not(hasKey("configs")))
+            .body("data.attributes.partitions", hasSize(2))
+            .body("data.attributes.partitions[0].offset.type", is(not("error")))
+            .body("data.attributes.partitions[0].offset.offset", is(1))
+            .body("data.attributes.partitions[0].offset.timestamp", is(second.toString()));
     }
 
     @Test

--- a/src/test/java/com/github/eyefloaters/console/api/service/ClusterServiceTest.java
+++ b/src/test/java/com/github/eyefloaters/console/api/service/ClusterServiceTest.java
@@ -12,7 +12,7 @@ class ClusterServiceTest {
 
     @Test
     void testEnumNames() {
-        List<String> result = ClusterService.enumNames(List.of(
+        List<String> result = KafkaClusterService.enumNames(List.of(
                 org.apache.kafka.common.acl.AclOperation.ALTER,
                 org.apache.kafka.common.acl.AclOperation.CLUSTER_ACTION,
                 org.apache.kafka.common.acl.AclOperation.DESCRIBE,
@@ -23,13 +23,13 @@ class ClusterServiceTest {
 
     @Test
     void testEnumNamesEmpty() {
-        List<String> result = ClusterService.enumNames(Collections.emptyList());
+        List<String> result = KafkaClusterService.enumNames(Collections.emptyList());
         assertEquals(Collections.emptyList(), result);
     }
 
     @Test
     void testEnumNamesNull() {
-        List<String> result = ClusterService.enumNames(null);
+        List<String> result = KafkaClusterService.enumNames(null);
         assertNull(result);
     }
 }

--- a/src/test/java/com/github/eyefloaters/console/api/support/SourceTest.java
+++ b/src/test/java/com/github/eyefloaters/console/api/support/SourceTest.java
@@ -1,0 +1,31 @@
+package com.github.eyefloaters.console.api.support;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.github.eyefloaters.console.api.model.ErrorSource;
+import com.github.eyefloaters.console.api.support.ErrorCategory.Source;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SourceTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "PARAMETER, parameter[value1]",
+        "POINTER, pointer[value1]",
+        "HEADER, header[value1]"
+    })
+    void testErrorSource(Source source, String toStringValue) {
+        ErrorSource errorSource = source.errorSource("value1");
+        assertEquals(toStringValue, errorSource.toString());
+    }
+
+    @Test
+    void testErrorSourceNull() {
+        assertNull(Source.NONE.errorSource("value1"));
+    }
+
+}

--- a/src/test/java/com/github/eyefloaters/console/api/support/SourceTest.java
+++ b/src/test/java/com/github/eyefloaters/console/api/support/SourceTest.java
@@ -28,4 +28,10 @@ class SourceTest {
         assertNull(Source.NONE.errorSource("value1"));
     }
 
+    @Test
+    void testErrorSourceEmpty() {
+        ErrorSource source = new ErrorSource(null, null, null);
+        assertEquals("empty", source.toString());
+    }
+
 }

--- a/src/test/java/com/github/eyefloaters/console/api/support/UuidValidatorTest.java
+++ b/src/test/java/com/github/eyefloaters/console/api/support/UuidValidatorTest.java
@@ -1,0 +1,30 @@
+package com.github.eyefloaters.console.api.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UuidValidatorTest {
+
+    UuidValidator target;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        target = new UuidValidator();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "                        , true",
+        "''                      , false",
+        "'dfGTCUxRSQWxpl--2Ditng', true",
+        "'invalid#$%^'           , false"
+    })
+    void testIsValid(String value, boolean expectedResult) {
+        boolean actualResult = target.isValid(value, null);
+        assertEquals(expectedResult, actualResult);
+    }
+
+}


### PR DESCRIPTION
Paths:
- Replace `clusters` path segment with `kafkas`
- Replace `brokers` with `nodes`
- Use topic ID instead of topic name
- Refactor models to use attributes property
- Validate path UUID
- Use records for immutable models
- Remove listInternal topics param
